### PR TITLE
Improve MNL estimation reliability

### DIFF
--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -446,6 +446,9 @@ def mnl_probs(data, beta, numalts):
         raise Exception("Number of alternatives is zero")
     utilities.reshape(numalts, utilities.size() // numalts)
 
+    # https://stats.stackexchange.com/questions/304758/softmax-overflow
+    utilities = utilities.subtract(utilities.max(0))
+    
     exponentiated_utility = utilities.exp(inplace=True)
     if clamp:
         exponentiated_utility.inftoval(1e20)
@@ -658,6 +661,9 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(-1000, 1000),
                                                bounds=bounds)
     logger.debug('finish: scipy optimization for MNL fit')
 
+    if bfgs_result[2]['warnflag'] > 0:
+        logger.warn("mnl did not converge correctly: %s",  bfgs_result)
+    
     beta = bfgs_result[0]
     stderr = mnl_loglik(
         beta, data, chosen, numalts, weights, stderr=1, lcgrad=lcgrad)

--- a/choicemodels/tools/pmat.py
+++ b/choicemodels/tools/pmat.py
@@ -79,6 +79,12 @@ class PMAT:
         # elif self.typ == 'cuda':
         #  return PMAT(misc.cumsum(self.mat,axis=axis))
 
+    def max(self, axis):
+        if self.typ == 'numpy':
+            return PMAT(np.max(self.mat, axis=axis))
+        elif self.typ == 'cuda':
+            return PMAT(self.mat.max(axis=axis))
+    
     def argmax(self, axis):
         if self.typ == 'numpy':
             return PMAT(np.argmax(self.mat, axis=axis))

--- a/notebooks/MNL-prediction-demo-02.ipynb
+++ b/notebooks/MNL-prediction-demo-02.ipynb
@@ -207,25 +207,17 @@
       "Method:       Maximum Likelihood   Df Model:                       \n",
       "Date:                              Pseudo R-squ.:                  \n",
       "Time:                              Pseudo R-bar-squ.:              \n",
-      "AIC:                               Log-Likelihood:       -4,502.369\n",
+      "AIC:                               Log-Likelihood:       -4,506.216\n",
       "BIC:                               LL-Null:              -4,605.170\n",
       "===================================================================\n",
       "                    coef   std err         z     P>|z|   Conf. Int.\n",
       "-------------------------------------------------------------------\n",
-      "home_density      0.0117     0.002     6.250                       \n",
-      "work_density      0.0123     0.001    15.292                       \n",
-      "school_density    0.0075     0.004     2.087                       \n",
+      "home_density      0.0113     0.002     6.051                       \n",
+      "work_density      0.0119     0.001    14.909                       \n",
+      "school_density    0.0069     0.004     1.916                       \n",
       "===================================================================\n",
-      "CPU times: user 546 ms, sys: 102 ms, total: 648 ms\n",
-      "Wall time: 245 ms\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/maurer/Dropbox/Git-imac/udst/choicemodels/choicemodels/tools/pmat.py:48: RuntimeWarning: overflow encountered in exp\n",
-      "  return PMAT(np.exp(self.mat))\n"
+      "CPU times: user 96.6 ms, sys: 55.7 ms, total: 152 ms\n",
+      "Wall time: 145 ms\n"
      ]
     }
    ],
@@ -271,9 +263,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0    0.011688\n",
-      "1    0.012314\n",
-      "2    0.007539\n",
+      "0    0.011321\n",
+      "1    0.011928\n",
+      "2    0.006929\n",
       "Name: Coefficient, dtype: float64\n"
      ]
     }
@@ -766,7 +758,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [item.strip() for item in install_requires]
 
 setup(
     name='choicemodels',
-    version='0.1.1',
+    version='0.2.dev1',
     description='Tools for discrete choice estimation',
     long_description=long_description,
     author='UDST',


### PR DESCRIPTION
This PR replicates the fixes from https://github.com/UDST/urbansim/pull/211.

- reduces likelihood of matrix overflow by rescaling the utilities before exponentiating them
- warns the user if `scipy.optimize.fmin_l_bfgs_b` reports not converging correctly

Versioning

- updates choicemodels version number to 0.2.dev1