### PR TITLE
MNL probabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,8 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set show_channel_urls true
   - conda update conda
-  - conda config --add channels conda-forge udst --force
+  - conda config --add channels conda-forge --force
+  - conda config --add channels udst --force
   - conda create --quiet --name TESTENV python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TESTENV
   - conda info --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set show_channel_urls true
   - conda update conda
-  - conda config --add channels conda-forge --force
+  - conda config --add channels conda-forge udst --force
   - conda create --quiet --name TESTENV python=$TRAVIS_PYTHON_VERSION --file requirements.txt --file requirements-dev.txt
   - source activate TESTENV
   - conda info --all

--- a/choicemodels/__init__.py
+++ b/choicemodels/__init__.py
@@ -4,4 +4,4 @@
 from .choicemodels import *
 from .mnl import MultinomialLogit, MultinomialLogitResults
 
-version = __version__ = '0.2.dev1'
+version = __version__ = '0.2.dev2'

--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -184,10 +184,10 @@ class MultinomialLogit(object):
          - verify chosen alternative listed first]
 
         """
-        self._data = self._data.reset_index().sort_values(by = [self._observation_id_col,
-                                                                self._choice_col],
-                                                          ascending = [True, False])
-        return
+        # Sort order is required by PyLogit
+        # self._data = self._data.reset_index().sort_values(by = [self._observation_id_col,
+        #                                                         self._choice_col],
+        #                                                   ascending = [True, False])
 
     
     def fit(self):
@@ -317,7 +317,7 @@ class MultinomialLogitResults(object):
         Generate predicted probabilities for a table of choice scenarios, using the fitted
         parameters stored in the results object.
         
-        TO DO - handle pylogit case
+        TO DO - make sure this handles pylogit case
         
         Parameters
         ----------
@@ -338,12 +338,12 @@ class MultinomialLogitResults(object):
         numalts = data.sample_size  # TO DO - make this an official MCT param
         
         dm = dmatrix(self.model_expression, data=df, return_type='dataframe')
-
+        
         # utility is sum of data values times fitted betas
         u = np.dot(self.fitted_parameters, np.transpose(dm))
         
         # reshape so axis 0 lists alternatives and axis 1 lists choosers
-        u = np.reshape(u, (numalts, u.size // numalts))
+        u = np.reshape(u, (numalts, u.size // numalts), order='F')
     
         # scale the utilities to make exponentiation easier
         # https://stats.stackexchange.com/questions/304758/softmax-overflow

--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -256,29 +256,12 @@ class MultinomialLogit(object):
 
 class MultinomialLogitResults(object):
     """
-    This is a work in progress. The rationale for having a separate results class is that
-    users don't have to keep track of which methods they're allowed to run depending on
-    the status of the object. An estimation object is always ready to estimate, and a
-    results object is always ready to report the results or predict.
-
-    Anticipated functionality:
-    - Store estimation results, test statistics, and other metadata
-    - Report these in a standard estimation results table
-    - Provide access to individual values as needed
-
-    Possible functionality:
-    - Write results to a human-readable text file, and read them back in? Currently this
-      is handled at a higher level by UrbanSim.
-    - Prediction?? Maybe this should be separate and take a results object as input..
-
-    Most of this functionality can be inherited from a generic results class; it doesn't
-    need to be MNL-specific. Statsmodels has some patterns for this that we could follow.
-    Or it might be best to do something that integrates with PyLogit as smoothly as
-    possible.
-
-    Note that the PyLogit estimation engine provides a full suite of output (test
-    statistics, p-values, confidence intervals, etc), while the ChoiceModels engine
-    only provides the basics at this point. More can be added as needed.
+    The results class represents a fitted model. It can report the model fit, generate
+    choice probabilties, etc.
+    
+    A full-featured results object is returned by MultinomialLogit.fit(). A results object
+    with more limited functionality can also be built directly from fitted parameters and
+    a model expression. (TO DO - latter not yet implemented)
 
     Parameters
     ----------

--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -178,10 +178,10 @@ class MultinomialLogit(object):
     
     def _validate_input_data(self):
         """
-        [TO DO for ChoiceModels engine:
+        TO DO for ChoiceModels engine:
          - verify number of alternatives consistent for each chooser
          - verify each chooser's alternatives in contiguous rows
-         - verify chosen alternative listed first]
+         - verify chosen alternative listed first
 
         """
         # Sort order is required by PyLogit
@@ -195,10 +195,9 @@ class MultinomialLogit(object):
         Fit the model using maximum likelihood estimation. Uses either the ChoiceModels
         or PyLogit estimation engine as appropriate.
 
-        [TO DO: should we add pass-through parameters here, or take them all in the
-        constructor?]
-
-        Parameters - NOT YET IMPLEMENTED
+        TO DO - implement parameters?
+        
+        Parameters
         ----------
         GPU : bool, optional
             GPU acceleration.
@@ -265,7 +264,7 @@ class MultinomialLogitResults(object):
     
     A full-featured results object is returned by MultinomialLogit.fit(). A results object
     with more limited functionality can also be built directly from fitted parameters and
-    a model expression. (TO DO - latter not yet implemented)
+    a model expression.
 
     Parameters
     ----------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 coverage >= 4.5
 coveralls >= 1.3
 pytest >= 3.4
+urbansim >= 3.1

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [item.strip() for item in install_requires]
 
 setup(
     name='choicemodels',
-    version='0.2.dev1',
+    version='0.2.dev2',
     description='Tools for discrete choice estimation',
     long_description=long_description,
     author='UDST',

--- a/tests/test_mnl_new.py
+++ b/tests/test_mnl_new.py
@@ -1,0 +1,47 @@
+"""
+These are tests for the refactored choicemodels codebase.
+
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import choicemodels
+
+
+d1 = {'oid': np.arange(100), 
+      'obsval': np.random.random(100),
+      'choice': np.random.choice(np.arange(5), size=100)}
+
+d2 = {'aid': np.arange(5), 
+      'altval': np.random.random(5)}
+
+obs = pd.DataFrame(d1).set_index('oid')
+alts = pd.DataFrame(d2).set_index('aid')
+
+
+def test_prediction():
+    import patsy
+    from urbansim.urbanchoice import mnl
+
+    # produce a fitted model
+    mct = choicemodels.tools.MergedChoiceTable(obs, alts, 'choice', 5)
+    m = choicemodels.MultinomialLogit(mct, model_expression='obsval + altval - 1')
+    results = m.fit()
+    
+    # get predicted probabilities using choicemodels
+    probs1 = results.probabilities(mct)
+    
+    # compare to probabilities from urbansim.urbanchoice
+    dm = patsy.dmatrix(results.model_expression, data=mct.to_frame(),
+                       return_type='dataframe')
+
+    probs = mnl.mnl_simulate(data=dm, coeff=results.fitted_parameters,
+                             numalts=mct.sample_size, returnprobs=True)
+
+    df = mct.to_frame()
+    df['prob'] = np.reshape(probs, (probs.size, 1))
+    probs2 = df.prob
+    
+    pd.testing.assert_series_equal(probs1, probs2)


### PR DESCRIPTION
This PR adds functionality to the `MultinomialLogitResults()` class for generating predicted probabilities. The code is fully refactored and no longer relies on `urbanism.urbanchoice`. 

This is one component of issue #26.

### Usage

```py
from choicemodels import MultinomialLogit
from choicemodels.tools import MergedChoiceTable

data = MergedChoiceTable(observations, alternatives, 'choice_col', sample_size)

model = MultinomialLogit(data, 'model_expression')
results = model.fit()

probs = results.probabilities(data)  # returns pd.Series with index matching input data
```

### Discussion

I made this a method of the results object because each model class will probably need special logic to generate predicted probabilities. After we have probabilities, the choice simulation can be model agnostic.

The `MultinomialLogitResults()` object is easy to regenerate, for template purposes or for users who want to do prediction with a model they estimated previously:

```py
from choicemodels import MultinomialLogitResults

results = MultinomialLogitResults(model_expression, fitted_parameters)
probs = results.probabilities(data)
```

### Refactoring

I refactored the underlying code because `urbansim.urbanchoice.mnl` didn't have a clear code path for this kind of use case. The logic is mostly drawn from [mnl_probs()](https://github.com/UDST/urbansim/blob/master/urbansim/urbanchoice/mnl.py#L30-L55), with some pre- and post-processing from [mnl_simulate()](https://github.com/UDST/urbansim/blob/master/urbansim/urbanchoice/mnl.py#L156-L164).

I removed the GPU acceleration option because it makes the code harder to work with and uses a library that isn't in active development any more. We may want to add this back in the future, or look into some other kind of acceleration.

Performance is good: 1.4 seconds to generate 10 million probabilities on a slow i5 MacBook, using either the old or new codebase.

This PR includes a unit test confirming that the predicted probabilities are identical in both codebases.

### Other changes

- adds a required `model_expression` parameter to the `MultinomialLogitResults` constructor
- simplifies storage of object properties

### Versioning

- updates the ChoiceModels version number to `0.2.dev2`