### PR TITLE
[0.2.dev5] Batch simulation for constrained choices

### DIFF
--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -78,7 +78,7 @@ def monte_carlo_choices(probabilities):
 
 
 def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callable, 
-        alt_capacity=None, chooser_size=None, max_iter=None, sample_frac=1):
+        alt_capacity=None, chooser_size=None, max_iter=None, sample_size=None):
     """
     Monte Carlo simulation of choices for a set of choice scenarios where (a) the 
     alternatives have limited capacity and (b) the choosers have varying probability 
@@ -169,9 +169,11 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
         if max_iter is not None:
             if (iter > max_iter):
                 break
+        if sample_size is None or sample_size > len(choosers):
+            mct = mct_callable(choosers.sample(frac=1), alts)
+        else:
+            mct = mct_callable(choosers.sample(sample_size), alts)
 
-        mct = mct_callable(choosers.sample(frac=sample_frac), alts)
-        
         if len(mct.to_frame()) == 0:
             print("No valid alternatives for the remaining choosers")
             break

--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -138,7 +138,7 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
         Maximum number of iterations. If None (default), the algorithm will iterate until 
         all choosers are matched or no alternatives remain.
 
-    choice_batch_size : int or None, optional
+    chooser_batch_size : int or None, optional
         Size of the batches for processing smaller groups of choosers one at a time. Useful
         when the anticipated size of the merged choice tables (choosers X alternatives
         X covariates) will be too large for python/pandas to handle. 
@@ -174,10 +174,10 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
         if max_iter is not None:
             if (iter > max_iter):
                 break
-        if choice_batch_size is None or choice_batch_size > len(choosers):
+        if chooser_batch_size is None or chooser_batch_size > len(choosers):
             mct = mct_callable(choosers.sample(frac=1), alts)
         else:
-            mct = mct_callable(choosers.sample(choice_batch_size), alts)
+            mct = mct_callable(choosers.sample(chooser_batch_size), alts)
 
         if len(mct.to_frame()) == 0:
             print("No valid alternatives for the remaining choosers")

--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -78,7 +78,7 @@ def monte_carlo_choices(probabilities):
 
 
 def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callable, 
-        alt_capacity=None, chooser_size=None, max_iter=None):
+        alt_capacity=None, chooser_size=None, max_iter=None, sample_frac=1):
     """
     Monte Carlo simulation of choices for a set of choice scenarios where (a) the 
     alternatives have limited capacity and (b) the choosers have varying probability 
@@ -170,7 +170,7 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
             if (iter > max_iter):
                 break
 
-        mct = mct_callable(choosers.sample(frac=1), alts)
+        mct = mct_callable(choosers.sample(frac=sample_frac), alts)
         
         if len(mct.to_frame()) == 0:
             print("No valid alternatives for the remaining choosers")

--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -78,7 +78,7 @@ def monte_carlo_choices(probabilities):
 
 
 def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callable, 
-        alt_capacity=None, chooser_size=None, max_iter=None, sample_size=None):
+        alt_capacity=None, chooser_size=None, max_iter=None, chooser_batch_size=None):
     """
     Monte Carlo simulation of choices for a set of choice scenarios where (a) the 
     alternatives have limited capacity and (b) the choosers have varying probability 
@@ -138,6 +138,11 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
         Maximum number of iterations. If None (default), the algorithm will iterate until 
         all choosers are matched or no alternatives remain.
 
+    choice_batch_size : int or None, optional
+        Size of the batches for processing smaller groups of choosers one at a time. Useful
+        when the anticipated size of the merged choice tables (choosers X alternatives
+        X covariates) will be too large for python/pandas to handle. 
+
     Returns
     -------
     pd.Series
@@ -169,10 +174,10 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
         if max_iter is not None:
             if (iter > max_iter):
                 break
-        if sample_size is None or sample_size > len(choosers):
+        if choice_batch_size is None or choice_batch_size > len(choosers):
             mct = mct_callable(choosers.sample(frac=1), alts)
         else:
-            mct = mct_callable(choosers.sample(sample_size), alts)
+            mct = mct_callable(choosers.sample(choice_batch_size), alts)
 
         if len(mct.to_frame()) == 0:
             print("No valid alternatives for the remaining choosers")


### PR DESCRIPTION
Per issue #47 this PR allows the user to specify a smaller chunk size of choosers to simulate choices in batches until complete. It required very little changes to the code, and I set the defaults so that they're backwards compatible with existing code, i.e. no changes are required unless someone chooses to enable this functionality.

### Before merging

- [ ] update version number (see below)