### PR TITLE
[0.2.dev7] MergedChoiceTable check for duplicate column names

### DIFF
--- a/choicemodels/__init__.py
+++ b/choicemodels/__init__.py
@@ -3,4 +3,4 @@
 
 from .mnl import MultinomialLogit, MultinomialLogitResults
 
-version = __version__ = '0.2.dev6'
+version = __version__ = '0.2.dev7'

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires = [item.strip() for item in install_requires]
 
 setup(
     name='choicemodels',
-    version='0.2.dev6',
+    version='0.2.dev7',
     description='Tools for discrete choice estimation',
     long_description=long_description,
     author='UDST',

--- a/tests/test_mct.py
+++ b/tests/test_mct.py
@@ -228,5 +228,3 @@ def test_join_key_name_conflict(obs, alts):
     MergedChoiceTable(obs, alts, chosen_alternatives=alts.index.name)
 
 
-
-    


### PR DESCRIPTION
This PR adds a check to the MergedChoiceTable constructor to make sure there aren't any column names that overlap between the observations and alternatives tables.

It's ok for the `chosen_alternatives` column of the observations table to have the same name as the index of the alternatives table, though.

### Discussion

This aligns ChoiceModels with the strategy for overlapping column names discussed in [UrbanSim Templates issue #67](https://github.com/UDST/urbansim_templates/issues/67). 

### Other changes

All the existing unit tests pass, and I wrote some new ones to test permutations of overlapping column names. 

### Versioning

- updates the version number to 0.2.dev7