### PR TITLE
Fixing a ReadTheDocs build problem

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,10 +36,9 @@ import sphinx_rtd_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
-             #'sphinx.ext.napoleon',
+              'sphinx.ext.napoleon',
               'sphinx.ext.viewcode',
-              'sphinx.ext.githubpages',
-              'numpydoc']
+              'sphinx.ext.githubpages']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,5 +3,4 @@ coveralls >= 1.3
 pytest >= 3.4
 urbansim >= 3.1
 sphinx
-numpydoc
 sphinx_rtd_theme


### PR DESCRIPTION
ReadTheDocs.org had an error building the prior PR, and rather than fiddling with customized build environments I'd like to get everything working using the defaults.

### Error

```
python /home/docs/checkouts/readthedocs.org/user_builds/choicemodels/envs/latest/bin/sphinx-build -T -E -b readthedocs -d _build/doctrees-readthedocs -D language=en . _build/html
Running Sphinx v1.7.9
loading translations [en]... done

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/choicemodels/envs/latest/local/lib/python2.7/site-packages/sphinx/cmdline.py", line 303, in main
    args.warningiserror, args.tags, args.verbosity, args.jobs)
  File "/home/docs/checkouts/readthedocs.org/user_builds/choicemodels/envs/latest/local/lib/python2.7/site-packages/sphinx/application.py", line 191, in __init__
    self.setup_extension(extension)
  File "/home/docs/checkouts/readthedocs.org/user_builds/choicemodels/envs/latest/local/lib/python2.7/site-packages/sphinx/application.py", line 411, in setup_extension
    self.registry.load_extension(self, extname)
  File "/home/docs/checkouts/readthedocs.org/user_builds/choicemodels/envs/latest/local/lib/python2.7/site-packages/sphinx/registry.py", line 318, in load_extension
    raise ExtensionError(__('Could not import extension %s') % extname, err)
ExtensionError: Could not import extension numpydoc (exception: No module named numpydoc)

Extension error:
Could not import extension numpydoc (exception: No module named numpydoc)
```

### Likely solution

Seems like Napoleon is the preferred Sphinx extension for parsing docstrings now, rather than Numpydoc (which I had copied from somewhere). 

Info: https://pypi.org/project/sphinxcontrib-napoleon/


### Versioning

unchanged