### PR TITLE
uniform stratified sampling of alts

### DIFF
--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -4,7 +4,7 @@ Utilities for Monte Carlo simulation of choices.
 """
 import numpy as np
 import pandas as pd
-from multiprocessing import Process, Manager, Array, cpu_count
+from multiprocessing import Process, Manager, Array, cpu_count, Pool
 from tqdm import tqdm
 import warnings
 
@@ -179,7 +179,7 @@ def iterative_lottery_choices(choosers, alternatives, mct_callable, probs_callab
                 break
         if alts[capacity].max() < choosers[size].min():
             print("{} choosers cannot be allocated.".format(len(choosers)))
-            print("\nRemaining capacity on alternatives but not enough to accodomodate choosers' sizes")
+            print("\nRemaining capacity on alternatives but not enough to accomodate choosers' sizes")
             break
         if chooser_batch_size is None or chooser_batch_size > len(choosers):
             mct = mct_callable(choosers.sample(frac=1), alts)
@@ -429,7 +429,7 @@ def parallel_lottery_choices(
         chooser_size = '_size'
         choosers.loc[:, chooser_size] = 1
 
-    if chooser_batch_size is None or chooser_batch_size > len(choosers):
+    if chooser_batch_size is None or chooser_batch_size >= len(choosers):
         obs_batches = [choosers.index.values]
     else:
         obs_batches = [


### PR DESCRIPTION
Implemented a new feature of the `MergedChoiceTable` class for performing uniform stratified sampling of alternatives. For use cases that require heavy sampling of alternatives to make the problem tractable (e.g. location choice models), we want to make sure that individual choice sets are still representative. Two new arguments/attributes to the `MergedChoiceTable` class, `sampling_regime` and `strata`, allow the user to trigger stratified sampling and to specify the column from the table of alternatives defines the strata groupings. Because we want each observation to have a representative choice set of alternatives, we have to iterate over each observation and generate choice sets one at a time. As a result, this new sampling method is just as slow as the various sampling without replacement methods even though we are sampling with replacement at a macro level. I think there may be a better way of doing this, whereby the choice sets for all observations can be constructed in one go, without iterating over observations, but I'll leave that for the time being.