### PR TITLE
New MergedChoiceTable feature: `from_df()` construction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install .
   - pip install -r requirements-dev.txt
-  - pip install orca, urbansim  # extra tests run if urbansim is present
+  - pip install orca urbansim  # extra tests run if urbansim is present
   - pip list
   - pip show choicemodels
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,10 @@ python:
   - "3.5"
   - "3.6"
 
-matrix:
-  include:
-    - python: "3.7"  # temp solution until travis supports python 3.7 more cleanly
-      dist: xenial
-      sudo: true
-
 install:
   - pip install .
   - pip install -r requirements-dev.txt
-  - # extra tests run if urbansim is present, but it can't install with python 3.7
-  - if [ "$TRAVIS_PYTHON_VERSION" != "3.7" ]; then pip install urbansim; fi
+  - pip install urbansim  # extra tests run if urbansim is present
   - pip list
   - pip show choicemodels
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "2.7"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 install:
   - pip install .

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 install:
   - pip install .
   - pip install -r requirements-dev.txt
-  - pip install urbansim  # extra tests run if urbansim is present
+  - pip install orca, urbansim  # extra tests run if urbansim is present
   - pip list
   - pip show choicemodels
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # ChoiceModels change log
-### 0.2.2dev0 (2019-04-23)
 
-- adds a function `choicemodels.tools.parallel_lottery_choices()` to run iterative lottery choice batches in parallel rather than seqeuentially.
+### 0.2.2.dev1 (2020-04-14)
+
+- adds a `MergedChoiceTable.from_df()` as an alternative constructor
+
+### 0.2.2.dev0 (2019-04-23)
+
+- adds a function `choicemodels.tools.parallel_lottery_choices()` to run iterative lottery choice batches in parallel rather than sequentially
 
 ### 0.2.1 (2019-01-30)
 

--- a/choicemodels/__init__.py
+++ b/choicemodels/__init__.py
@@ -3,4 +3,4 @@
 
 from .mnl import MultinomialLogit, MultinomialLogitResults
 
-version = __version__ = '0.2.2dev0'
+version = __version__ = '0.2.2.dev1'

--- a/choicemodels/tools/mergedchoicetable.py
+++ b/choicemodels/tools/mergedchoicetable.py
@@ -183,6 +183,30 @@ class MergedChoiceTable(object):
             self._merged_table = self._build_table()
         
         
+    @classmethod
+    def from_df(cls, df):
+        """
+        Create an object instance from a dataframe
+
+        Parameters
+        ----------
+        df : a Pandas DataFrame object with 1) a MultiIndex in which the
+        first level corresponds to the index of the observations and the
+        second to the index of the alternatives; and 2) a binary column
+        named 'chosen' that indicated whether the corresponding 
+        alternative was chosen in the observation data.
+        
+        Returns
+        -------
+        MergedChoiceTable
+
+        """
+        obj = cls(pd.DataFrame(), pd.DataFrame())
+        obj._merged_table = df
+
+        return obj
+
+
     def _merge_interaction_terms(self, df):
         """
         Merges interaction terms (if they exist) onto the input DataFrame. 

--- a/choicemodels/tools/mergedchoicetable.py
+++ b/choicemodels/tools/mergedchoicetable.py
@@ -177,15 +177,17 @@ class MergedChoiceTable(object):
         self.weights_2d = weights_2d
         
         # Build choice table...
+        # Allow missing obs and alts, to support .from_df() constructor     
+        if (observations is not None):
 
-        if (len(observations) == 0) or (len(alternatives) == 0):
-            self._merged_table = pd.DataFrame()
+            if (len(observations) == 0) or (len(alternatives) == 0):
+                self._merged_table = pd.DataFrame()
         
-        elif (sample_size is None):
-            self._merged_table = self._build_table_without_sampling()
+            elif (sample_size is None):
+                self._merged_table = self._build_table_without_sampling()
         
-        else:
-            self._merged_table = self._build_table()
+            else:
+                self._merged_table = self._build_table()
         
         
     @classmethod

--- a/choicemodels/tools/mergedchoicetable.py
+++ b/choicemodels/tools/mergedchoicetable.py
@@ -186,22 +186,34 @@ class MergedChoiceTable(object):
     @classmethod
     def from_df(cls, df):
         """
-        Create an object instance from a dataframe
+        Create an object instance from a dataframe.
+
+        The MergedChoiceTable class requires two dataframes to initialize
+        representing observations and alternatives for the choice scenario,
+        so this classmethod simply passes in two empty dataframes. Similarly,
+        it also passes a dummy for the `chosen_alternatives` arg in order
+        to trigger the creation of the `MergedChoiceTable.choice_col` property.
 
         Parameters
         ----------
         df : a Pandas DataFrame object with 1) a MultiIndex in which the
         first level corresponds to the index of the observations and the
         second to the index of the alternatives; and 2) a binary column
-        named 'chosen' that indicated whether the corresponding 
+        named 'chosen' that indicated whether the corresponding
         alternative was chosen in the observation data.
+
+        choice_col : Name of the column containing a binary representation
+        of whether each alternative was chosen in the given choice scenario.
         
         Returns
         -------
         MergedChoiceTable
 
         """
-        obj = cls(pd.DataFrame(), pd.DataFrame())
+        obj = cls(
+            observations=pd.DataFrame(),
+            alternatives=pd.DataFrame(),
+            chosen_alternatives=-999)
         obj._merged_table = df
 
         return obj

--- a/choicemodels/tools/mergedchoicetable.py
+++ b/choicemodels/tools/mergedchoicetable.py
@@ -191,24 +191,18 @@ class MergedChoiceTable(object):
     @classmethod
     def from_df(cls, df):
         """
-        Create an object instance from a dataframe.
+        Create a MergedChoiceTable instance from a pre-generated DataFrame.
 
-        The MergedChoiceTable class requires two dataframes to initialize
-        representing observations and alternatives for the choice scenario,
-        so this classmethod simply passes in two empty dataframes. Similarly,
-        it also passes a dummy for the `chosen_alternatives` arg in order
-        to trigger the creation of the `MergedChoiceTable.choice_col` property.
+        Each chooser's rows should be contiguous. If applicable, the chosen alternative
+        should be listed first. This ordering is used by MergedChoiceTable.to_frame(),
+        and appears to be an undocumented requirement of the legacy MNL code.
 
         Parameters
         ----------
-        df : a Pandas DataFrame object with 1) a MultiIndex in which the
-        first level corresponds to the index of the observations and the
-        second to the index of the alternatives; and 2) a binary column
-        named 'chosen' that indicated whether the corresponding
-        alternative was chosen in the observation data.
-
-        choice_col : Name of the column containing a binary representation
-        of whether each alternative was chosen in the given choice scenario.
+        df : pandas.DataFrame
+            Table with a two-level MultiIndex where the first level corresponds to the
+            index of the observations and the second to the index of the alternatives.
+            May include a binary column named 'chosen' indicating observed choices.
         
         Returns
         -------
@@ -217,7 +211,9 @@ class MergedChoiceTable(object):
         """
         obj = cls(observations = None, alternatives = None)
         obj._merged_table = df
-
+        
+        # TO DO: sort the dataframe so that rows are automatically in a consistent order
+        
         return obj
 
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ ChoiceModels
 
 ChoiceModels is a Python library for discrete choice modeling, with utilities for sampling, simulation, and other ancillary tasks. It's part of the `Urban Data Science Toolkit <https://docs.udst.org>`__ (UDST).
 
-v0.2.2dev0, released April 23, 2019
+v0.2.2.dev1, released April 14, 2020
 
 
 Contents

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-future >= 0.16
-numpy >= 1.14
-pandas >= 0.23
-patsy >= 0.5
-pylogit >= 0.2.2
-scipy >= 1.0
-statsmodels >= 0.8

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,6 @@ from setuptools import setup
 with open('README.md', 'r') as f:
     long_description = f.read()
 
-with open('requirements.txt') as f:
-    install_requires = f.readlines()
-install_requires = [item.strip() for item in install_requires]
-
 setup(
     name='choicemodels',
     version='0.2.2dev0',

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,13 @@ setup(
         'License :: OSI Approved :: BSD License'
     ],
     packages=['choicemodels', 'choicemodels.tools'],
-    install_requires=install_requires
+    install_requires=[
+        'numpy >= 1.14',
+        'pandas >= 0.23',
+        'patsy >= 0.5',
+        'pylogit >= 0.2.2',
+        'scipy >= 1.0',
+        'statsmodels >= 0.8, <0.11; python_version <"3.6"',
+        'statsmodels >= 0.8; python_version >="3.6"'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r') as f:
 
 setup(
     name='choicemodels',
-    version='0.2.2dev0',
+    version='0.2.2.dev1',
     description='Tools for discrete choice estimation',
     long_description=long_description,
     author='UDST',
@@ -19,6 +19,8 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'License :: OSI Approved :: BSD License'
     ],
     packages=['choicemodels', 'choicemodels.tools'],

--- a/tests/test_mct.py
+++ b/tests/test_mct.py
@@ -228,3 +228,55 @@ def test_join_key_name_conflict(obs, alts):
     MergedChoiceTable(obs, alts, chosen_alternatives=alts.index.name)
 
 
+def test_obs_id_property(obs, alts):
+    """
+    Observation id should be available for a merged table.
+    
+    """
+    mct = choicemodels.tools.MergedChoiceTable(obs, alts, 
+                                 sample_size = 2,
+                                 chosen_alternatives = 'choice')
+    
+    assert(mct.observation_id_col == 'oid')
+
+
+def test_alt_id_property(obs, alts):
+    """
+    Alternative id should be available for a merged table.
+    
+    """
+    mct = choicemodels.tools.MergedChoiceTable(obs, alts, 
+                                 sample_size = 2,
+                                 chosen_alternatives = 'choice')
+    
+    assert(mct.alternative_id_col == 'aid')
+
+
+def test_choice_col_property(obs, alts):
+    """
+    Choice column property should be present if applicable, or None.
+    
+    """
+    mct = choicemodels.tools.MergedChoiceTable(obs, alts, 
+                                 sample_size = 2,
+                                 chosen_alternatives = 'choice')
+    assert(mct.choice_col == 'chosen')
+
+    mct = choicemodels.tools.MergedChoiceTable(obs, alts, 
+                                 sample_size = 2)
+    assert(mct.choice_col == None)
+
+
+def test_from_df(obs, alts):
+    """
+    MCT creation from a dataframe should work smoothly.
+    
+    """
+    df = choicemodels.tools.MergedChoiceTable(obs, alts, 
+                                 sample_size = 2,
+                                 chosen_alternatives = 'choice').to_frame()
+    
+    mct = choicemodels.tools.MergedChoiceTable.from_df(df)
+    
+    assert(df.equals(mct.to_frame()))
+


### PR DESCRIPTION
This is a feature we've wanted for a long time, the ability to create a MergedChoiceTable object from a dataframe. This gives the user the ability to create an mct using the standard choicemodels workflow, but to then extract it, manipulate it, add new terms, and cast it back to an object that can be used by urbansim_templates or choicemodels once again. 

My goal was to make as few changes as possible to the core class structure, and as a result my solution is not the most elegant. It relies on the instantiation of two empty dataframes and a wrongly typed class attribute to satisfy what are currently required parameters of the MergedChoiceTable class. I'm open to suggestions if we think there's a better way to achieve the intended result.