### PR TITLE
fix for lottery choice bug for empty alts table

### DIFF
--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -184,9 +184,9 @@ def iterative_lottery_choices(
         if max_iter is not None:
             if (iter > max_iter):
                 break
-        if alts[capacity].max() < choosers[size].min():
+        if (alts[capacity].max() < choosers[size].min()) or (len(alts) == 0):
             print("{} choosers cannot be allocated.".format(len(choosers)))
-            print("\nRemaining capacity on alternatives but not enough to accodomodate choosers' sizes")
+            print("\nRemaining capacity on alternatives but not enough to accommodate choosers' sizes")
             break
         if chooser_batch_size is None or chooser_batch_size > len(choosers):
             mct = mct_callable(


### PR DESCRIPTION
This PR fixes a bug in`iterative_lottery_choices()` which creates an empty merged choice table object if/when all rows of alts table are filled and dropped before max capacity is exceeded. 