### PR TITLE
Improve optimization

### DIFF
--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -715,6 +715,7 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(None, None),
     aic = -2 * ll + 2 * len(beta)
 
     log_likelihood = {
+        "model_converged": bfgs_result[2]['warnflag'] > 0,
         'null': float(l0[0][0]),
         'convergence': float(l1[0][0]),
         'ratio': float((1 - (l1 / l0))[0][0]),

--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -586,7 +586,7 @@ def mnl_loglik(beta, data, chosen, numalts, weights=None, lcgrad=False,
     return -1 * loglik, -1 * gradarr
 
 
-def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(-1000, 1000),
+def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(None, None),
                  weights=None, lcgrad=False, beta=None):
     """
     Calculate coefficients of the MNL model.

--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -689,7 +689,7 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(None, None),
                                                beta,
                                                args=args,
                                                fprime=None,
-                                               factr=10,
+                                               factr=10e9,
                                                approx_grad=False,
                                                bounds=bounds)
     logger.debug('finish: scipy optimization for MNL fit')

--- a/choicemodels/mnl.py
+++ b/choicemodels/mnl.py
@@ -715,7 +715,7 @@ def mnl_estimate(data, chosen, numalts, GPU=False, coeffrange=(None, None),
     aic = -2 * ll + 2 * len(beta)
 
     log_likelihood = {
-        "model_converged": bfgs_result[2]['warnflag'] > 0,
+        "model_converged": bfgs_result[2]['warnflag'] == 0,
         'null': float(l0[0][0]),
         'convergence': float(l1[0][0]),
         'ratio': float((1 - (l1 / l0))[0][0]),

--- a/choicemodels/tools/simulation.py
+++ b/choicemodels/tools/simulation.py
@@ -176,7 +176,7 @@ def iterative_lottery_choices(
     capacity, size = (alt_capacity, chooser_size)
     
     len_choosers = len(choosers)
-    valid_choices = pd.Series()
+    valid_choices = pd.Series(dtype='float64')
     iter = 0
     
     while (len(valid_choices) < len_choosers):


### PR DESCRIPTION
Hello @smmaurer and perhaps others. My team is using choicemodels to estimate some relatively large location choice models in a land use model setting and we have been having a lot of problems with convergence (using `engine == "ChoiceModels"`). In searching for suggestions on what we might be doing wrong, I've noticed a few similar issues around, notably the one at https://github.com/UDST/urbansim/pull/212 from 2018.

I think I might have found the culprit... Please feel free to ignore the first commit here, I'm not sure that it is material at all though it did initially seem to allow some models to converge which were failing with strange errors before. I think in particular the value of `factr` is set to be too small when calling `scipy.optimize.fmin_l_bfgs_b()`

> The iteration stops when `(f^k - f^{k+1})/max{|f^k|,|f^{k+1}|,1} <= factr * eps`, where `eps` is the machine precision, which is automatically generated by the code. Typical values for `factr` are: 1e12 for low accuracy; 1e7 for moderate accuracy; 10.0 for extremely high accuracy.

I don't know what a minimum value for `factr` might be to achieve "extremely high accuracy" but I think machine precision times ten might be too high of a bar. Changing this to `factr=10e9` gets reasonably close to the tolerances being used in `pylogit` (`1e-06`) once divided by `eps`. The implementation of `scipy.optimize.minimize()` that `pylogit` uses internally calls the same function that you are using here.

Along with loosening this tolerance, I think another improvement might be to move to using that `scipy.optimimze.minimize()` interface here in choicemodels. I did see a comment somewhere in a scipy issue that directly calling the optimizers themselves should be considered deprecated. I'd be happy to tackle that change if you'd be interested in merging.

What do you think?